### PR TITLE
Remove duplicate nokogiri entry from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gem 'jekyll-paginate'
 gem 'jekyll-gist'
 gem 'nokogiri'
 gem 'jekyll-scalafiddle'
-
-gem 'nokogiri'


### PR DESCRIPTION
Fixes bundle warning:
```
Your Gemfile lists the gem nokogiri (>= 0) more than once.
You should probably keep only one of them.
```