### PR TITLE
Update observable-comparisons.md

### DIFF
--- a/_tut/docs/3x/reactive/observable-comparisons.md
+++ b/_tut/docs/3x/reactive/observable-comparisons.md
@@ -63,7 +63,7 @@ By contrast the Monix `Observable`:
   actors, with the exposed operators being awesome
   
 Reactive streaming libraries in general and the Monix `Observable` in
-particular are bad because they are good for modeling unidirectional
+particular are good for modeling unidirectional
 communications, but it gets complicated if you want bidirectional
 communications (possible, but complicated), with actors being better
 at having dialogs.


### PR DESCRIPTION
removing "are bad because they are good" phrasing. I had to re-read the start of the sentence three times before I could believe my eyes. However, removing the "bad" part does not change the overall meaning of the sentence and reads nicer.