### PR TITLE
Fix Observable demo code

### DIFF
--- a/_tut/docs/3x/reactive/observable.md
+++ b/_tut/docs/3x/reactive/observable.md
@@ -155,7 +155,7 @@ complicated then they really are.
 Imagine following situation:
 
 ```scala
-Observable.fromIterable(1, 2, 3)
+Observable.fromIterable(1 to 3)
   .map(i => i + 2)
   .map(i => i * 3)
   .sum


### PR DESCRIPTION
The current demo code for `Observable.fromIterable` won't compile, since the argument(s) passed to `fromIterable` isn't `Iterable` type.