### PR TITLE
Fix broken link

### DIFF
--- a/_tut/docs/3x/reactive/observable.md
+++ b/_tut/docs/3x/reactive/observable.md
@@ -452,7 +452,7 @@ Task
 In this case we transformed `Future` to `Task` so the example is pure (other than not suspending `ConcurrentSubject` creation) but you
 don't have to do that if you prefer staying with `Future`.
 
-[More on Subjects later.](/observable.html#subjects)
+[More on Subjects later.](#subjects)
 
 ## Scheduling
 


### PR DESCRIPTION
`/observable.html#subjects` is not right, it should be `/docs/3x/reactive/observable.html#subjects`. But since this link is referencing the same document, `#subjects` should be good.