### PR TITLE
Adding page on presentation from Typelevel Summit 2020, by Piotr Gawryś

### DIFF
--- a/presentations/2019-functional-concurrency-in-scala-101.md
+++ b/presentations/2019-functional-concurrency-in-scala-101.md
@@ -4,7 +4,6 @@ title: "Functional Concurrency in Scala 101"
 description: |
   Presentation from ScalaMatsuri 2019, by Piotr Gawryś, on concurrency basics in FP.
 comments: true
-image: /public/images/thumbs/2019-functional-concurrency-in-scala-101-piotr-gawrys.png
 author: Avasil
 youtube: MeOs9SeO8-c
 ---

--- a/presentations/2020-sleeping-well-lion-den-monix-catnap-piotr-gawrys.md
+++ b/presentations/2020-sleeping-well-lion-den-monix-catnap-piotr-gawrys.md
@@ -1,0 +1,34 @@
+---
+layout: page
+title: "Sleeping well in the lion's den with Monix Catnap"
+description: |
+  Presentation from Typelevel Summit 2020, by Piotr Gawryś
+comments: true
+author: Avasil
+youtube: gU0NJwKfDG8
+---
+
+Presentation from
+[Typelevel Summit 2020](https://typelevel.org/event/2020-03-summit-nyc/) by
+[Piotr Gawryś](https://twitter.com/p_gawrys):
+
+{% include youtube.html ratio=56.25 %}
+
+Resources:
+
+- [Slides](https://slides.com/avasil/monix-catnap-ea7c27){:target="blank"}
+- [API Documentation]({{ site.api3x }}monix/catnap/index.html)
+
+## Abstract
+
+Concurrency bugs leave you restless? Monix Catnap provides a ton of
+utilities that will let your worries take a good nap!
+
+Monix Catnap and Execution are rather unknown modules of Monix which
+have a lot of useful features like Local, `ConcurrentQueue` and
+`ConcurrentChannel` for everyone to use regardless of their effect of
+choice.
+
+The talk will cover some of the most interesting ones and show how
+they could be of use in your projects.
+

--- a/presentations/index.md
+++ b/presentations/index.md
@@ -8,6 +8,8 @@ comments: true
 
 ## Conferences
 
+- [Sleeping well in the lion's den with Monix Catnap]({% link presentations/2020-sleeping-well-lion-den-monix-catnap-piotr-gawrys.md %})<br/>
+  by Piotr Gawryś, [Typelevel Summit 2020](https://typelevel.org/event/2020-03-summit-nyc/)
 - [Functional Concurrency in Scala 101](./2019-functional-concurrency-in-scala-101.html) (repeat with Japanese slides subtitles)<br />
   by Piotr Gawryś, [ScalaMatsuri 2019](https://2019.scalamatsuri.org/index_en.html)
 - [Dispelling magic behind Concurrency in FP](./2019-dispelling-magic-behind-concurrency-in-fp.html)<br />


### PR DESCRIPTION
Couldn't find the abstract, found one from a local meetup.

BTW — us specifying an article image for these video presentations is no longer necessary, the template links automatically to YouTube's thumbnail if `youtube` ID is provided, so it will look nice in Twitter/Facebook cards.