### PR TITLE
fix a few broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Then to generate the whole website:
 
 ### Incremental compilation
 
-To generate the `mdoc`-enabled articles, which takes articles from [./_docs][./_docs], generating them parsed into `./docs`:
+To generate the `mdoc`-enabled articles, which takes articles from [./_docs](./_docs), generating them parsed into `./docs`:
 
 ```
 sbt mdoc

--- a/_docs/2x/eval/task.md
+++ b/_docs/2x/eval/task.md
@@ -154,8 +154,8 @@ giants. But where the Monix Task implementation disagrees:
    to), but from the consumer's point of view having a `def run: A`
    means that the API cannot be fully supported on top of Javascript
    and on top of the JVM it means that the `Task` ends up faking
-   synchronous evaluation and blocking threads. And [blocking threads
-   is very unsafe](../best-practices/blocking.md).
+   synchronous evaluation and blocking threads. And
+   [blocking threads is very unsafe](../best-practices/blocking.md).
 3. The Scalaz Task cannot cancel running computations. This is
    important for nondeterministic operations. For example when you
    create a race condition with a `chooseFirstOf`, you may want to

--- a/_docs/3x/eval/task.md
+++ b/_docs/3x/eval/task.md
@@ -153,8 +153,8 @@ giants. But where the Monix Task implementation disagrees:
    to), but from the consumer's point of view having a `def run: A`
    means that the API cannot be fully supported on top of Javascript
    and on top of the JVM it means that the `Task` ends up faking
-   synchronous evaluation and blocking threads. And [blocking threads
-   is very unsafe](../best-practices/blocking.md).
+   synchronous evaluation and blocking threads. And
+   [blocking threads is very unsafe](../best-practices/blocking.md).
 3. The Scalaz Task cannot cancel running computations. This is
    important for nondeterministic operations. For example when you
    create a race condition with a `race`, you may want to


### PR DESCRIPTION
Looks like the link is broken in https://monix.io/docs/current/eval/task.html#comparison-with-the-scalaz-task. Even
though the link is properly rendered, it links to `docs/current/best-practices/blocking.md` instead of `docs/current/best-practices/blocking.html`.

Not having the new line in the link seems to fix it when tested locally.

Also fix one link in the readme.